### PR TITLE
Fix dark styles in articles with white background

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -70,10 +70,9 @@ article:nth-child(5) {
       color: var(--White);
       opacity: 50%;
     }
-  }
-
-  .gray {
-    color: var(--Very-dark-grayish-blue) !important;
+    .gray {
+      color: var(--Very-dark-grayish-blue);
+    }
   }
 }
 
@@ -86,4 +85,8 @@ article:nth-child(5) {
 .summary {
   color: var(--Light-gray);
   opacity: 0.7;
+}
+
+.gray {
+  color: var(--Very-dark-grayish-blue);
 }


### PR DESCRIPTION
Using `!important` is not considered a good practice, so I decide to investigate a better solution.

I found that the following snippet was applied inside the `.user` class but not directly inside `.name`: 
 
 ```css
.gray {
      color: var(--Very-dark-grayish-blue);
    }
 ```
 
I moved it to the correct position to ensure proper styling.
 
Additionally, I added an extra `.gray` class after the `.title` class to override its styles when necessary.

This approach improves maintainability and avoids the use of `!important`